### PR TITLE
 Set pulseaudio sink port in audio jack detection 

### DIFF
--- a/etc/acpi/jack.sh
+++ b/etc/acpi/jack.sh
@@ -4,7 +4,7 @@
 #
 
 event="$*"
-PULSE_SERVER="tcp:localhost"
+export PULSE_SERVER="tcp:localhost"
 
 headphones_in() {
   pactl set-sink-port @DEFAULT_SINK@ "[Out] Headphones"

--- a/etc/acpi/jack.sh
+++ b/etc/acpi/jack.sh
@@ -4,17 +4,14 @@
 #
 
 event="$*"
+PULSE_SERVER="tcp:localhost"
 
 headphones_in() {
-  #pacmd set-sink-port "alsa_output.platform-cht-bsw-rt5645.HiFi__hw_chtrt5650__sink" "[Out] Headphones"
-  /usr/bin/amixer -c 0 cset name='Speaker Channel Switch' off
-  /usr/bin/amixer -c 0 cset name='Headphone Channel Switch' on
+  pactl set-sink-port @DEFAULT_SINK@ "[Out] Headphones"
 }
 
 headphones_out() {
-  #pacmd set-sink-port "alsa_output.platform-cht-bsw-rt5645.HiFi__hw_chtrt5650__sink" "[Out] Speaker"
-  /usr/bin/amixer -c 0 cset name='Headphone Channel Switch' off
-  /usr/bin/amixer -c 0 cset name='Speaker Channel Switch' on
+  pactl set-sink-port @DEFAULT_SINK@ "[Out] Speaker"
 }
 
 case "$event" in

--- a/etc/pulse/default.pa
+++ b/etc/pulse/default.pa
@@ -79,11 +79,11 @@ load-module module-bluetooth-discover
 load-module module-esound-protocol-unix
 .endif
 load-module module-native-protocol-unix
+load-module module-native-protocol-tcp
 
 ### Network access (may be configured with paprefs, so leave this commented
 ### here if you plan to use paprefs)
 #load-module module-esound-protocol-tcp
-#load-module module-native-protocol-tcp
 #load-module module-zeroconf-publish
 
 ### Load the RTP receiver module (also configured via paprefs, see above)


### PR DESCRIPTION
Load module-native-protocol-tcp so that the PulseAudio server can receive commands over TCP. During audio jack detection, set the sink port to either headphones or speaker using the default sink which gets configured based on the chromebook model [here](https://github.com/GalliumOS/galliumos-braswell/blob/c400d1376336b8773b11ff6f2ae13841993b2192/etc/pulse/default.pa#L167-L198).
 
Resolves GalliumOS/galliumos-distro#318